### PR TITLE
Flatten the labels specified by docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,24 +21,20 @@ USER cardboardci
 ARG build_date
 ARG version
 ARG vcs_ref
-LABEL maintainer = "CardboardCI" \
-    \
-    org.label-schema.schema-version = "1.0" \
-    \
-    org.label-schema.name = "hadolint" \
-    org.label-schema.version = "${version}" \
-    org.label-schema.build-date = "${build_date}" \
-    org.label-schema.release= = "CardboardCI version:${version} build-date:${build_date}" \
-    org.label-schema.vendor = "cardboardci" \
-    org.label-schema.architecture = "amd64" \
-    \
-    org.label-schema.summary = "Dockerfile linter" \
-    org.label-schema.description = "Dockerfile linter, validate inline bash, written in Haskell" \
-    \
-    org.label-schema.url = "https://gitlab.com/cardboardci/images/hadolint" \
-    org.label-schema.changelog-url = "https://gitlab.com/cardboardci/images/hadolint/releases" \
-    org.label-schema.authoritative-source-url = "https://cloud.docker.com/u/cardboardci/repository/docker/cardboardci/hadolint" \
-    org.label-schema.distribution-scope = "public" \
-    org.label-schema.vcs-type = "git" \
-    org.label-schema.vcs-url = "https://gitlab.com/cardboardci/images/hadolint" \
-    org.label-schema.vcs-ref = "${vcs_ref}" \
+LABEL maintainer="CardboardCI"
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.name="hadolint"
+LABEL org.label-schema.version="${version}"
+LABEL org.label-schema.build-date="${build_date}"
+LABEL org.label-schema.release="CardboardCI version:${version} build-date:${build_date}"
+LABEL org.label-schema.vendor="cardboardci"
+LABEL org.label-schema.architecture="amd64"
+LABEL org.label-schema.summary="Dockerfile linter"
+LABEL org.label-schema.description="Dockerfile linter, validate inline bash, written in Haskell"
+LABEL org.label-schema.url="https://gitlab.com/cardboardci/images/hadolint"
+LABEL org.label-schema.changelog-url="https://gitlab.com/cardboardci/images/hadolint/releases"
+LABEL org.label-schema.authoritative-source-url="https://cloud.docker.com/u/cardboardci/repository/docker/cardboardci/hadolint"
+LABEL org.label-schema.distribution-scope="public"
+LABEL org.label-schema.vcs-type="git"
+LABEL org.label-schema.vcs-url="https://gitlab.com/cardboardci/images/hadolint"
+LABEL org.label-schema.vcs-ref="${vcs_ref}"


### PR DESCRIPTION
The previous way of laying out the labels was causing some syntax issues, and made reading the image a bit difficult. For now I think it is best to just have all of the labels as their own line (layer).

This PR coverts the labels from a single layer to multiple layers (e.g. multiple LABEL commands). This resolves syntax errors with the labels, as well as keeping them a bit more consistent in style.